### PR TITLE
Added ScreenShake. Improved ball loop prevention

### DIFF
--- a/Assets/Scenes/Level 2.unity
+++ b/Assets/Scenes/Level 2.unity
@@ -139,7 +139,7 @@ PrefabInstance:
     - target: {fileID: 3856355251310777401, guid: 1ee4667d835175346ae4dbcd86a8b793,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3856355251310777401, guid: 1ee4667d835175346ae4dbcd86a8b793,
         type: 3}
@@ -364,7 +364,7 @@ PrefabInstance:
     - target: {fileID: 3856355251310777401, guid: 1ee4667d835175346ae4dbcd86a8b793,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3856355251310777401, guid: 1ee4667d835175346ae4dbcd86a8b793,
         type: 3}
@@ -805,7 +805,7 @@ PrefabInstance:
     - target: {fileID: 3856355251310777401, guid: 1ee4667d835175346ae4dbcd86a8b793,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3856355251310777401, guid: 1ee4667d835175346ae4dbcd86a8b793,
         type: 3}
@@ -934,6 +934,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7cc602e9dcb966e4ab35849d2729fc91, type: 3}
+--- !u!1 &1327049323 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7840114497438046155, guid: 89bfcbcf17c67074993dc6e73f5a749c,
+    type: 3}
+  m_PrefabInstance: {fileID: 7840114497027718265}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1327049324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1327049323}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c8a03ea70f482948b66d0c56c903062, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shakeTime: 0.1
+  initialShakePower: 0.1
 --- !u!1001 &1378646273
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -11,6 +11,9 @@ public class Ball : MonoBehaviour
     Vector2 paddleToBallVector;
     public bool ballLocked = true;
 
+    // Cached references
+    ScreenShakeController shakeController;
+
     // Cached component references
     AudioSource audioSource;
     AudioSource hitSound;
@@ -27,14 +30,15 @@ public class Ball : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        Debug.Log("Ball velocity: " + rb.velocity.x + ", " + rb.velocity.y);
+
         if (ballLocked)
-        {
             LockBallToPaddle();
-        }
     }
 
     private void InitializeCachedReferences()
     {
+        shakeController = FindObjectOfType<ScreenShakeController>();
         audioSource = GetComponent<AudioSource>();
         hitSound = transform.GetChild(0).GetComponent<AudioSource>();
         cloneSound = transform.GetChild(1).GetComponent<AudioSource>();
@@ -49,15 +53,19 @@ public class Ball : MonoBehaviour
 
     private void OnCollisionEnter2D(Collision2D collision)
     {
-        float x = Random.Range(0f, randomFactor);
-        float y = Random.Range(0f, randomFactor);
-        Vector2 velocityTweak = new Vector2(x, y);
+        shakeController.startShake();
 
         if (!ballLocked && collision.gameObject.tag != "Breakable")
         {
             AudioClip clip = ballSounds[Random.Range(0, ballSounds.Length)];
             audioSource.PlayOneShot(clip);
-            rb.velocity += velocityTweak;
+
+            if (rb.velocity.y <= 1 && rb.velocity.y >= -1)
+            {
+                float y = Random.Range(0f, randomFactor);
+                Vector2 velocityTweak = new Vector2(0, -y);
+                rb.velocity += velocityTweak;
+            }
         }
     }
 }

--- a/Assets/Scripts/ScreenShakeController.cs
+++ b/Assets/Scripts/ScreenShakeController.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ScreenShakeController : MonoBehaviour
+{
+    // Configuration parameters
+    [SerializeField] float shakeTime = 0.1f;
+    [SerializeField] float initialShakePower = 0.1f;
+
+    // Cached references
+    private Vector3 targetPos;
+
+    // State variables
+    private float shakeTimeRemaining;
+    private float shakePower;
+    private float shakeFadeTime;
+
+    private void Start()
+    {
+        targetPos = transform.position;
+    }
+
+    private void Update()
+    {    
+        transform.position = targetPos;
+    }
+
+    private void LateUpdate()
+    {
+        if (shakeTimeRemaining > 0)
+        {
+            shakeTimeRemaining -= Time.deltaTime;
+
+            float xAmount = Random.Range(-1f, 1f) * shakePower;
+            float yAmount = Random.Range(-1f, 1f) * shakePower;
+
+            transform.position += new Vector3(xAmount, yAmount, 0f);
+
+            shakePower = Mathf.MoveTowards(shakePower, 0f, shakeFadeTime * Time.deltaTime);
+        }
+    }
+
+    public void startShake()
+    {
+        shakeTimeRemaining = shakeTime;
+        shakePower = initialShakePower;
+
+        shakeFadeTime = initialShakePower / shakeTime;
+    }
+}

--- a/Assets/Scripts/ScreenShakeController.cs.meta
+++ b/Assets/Scripts/ScreenShakeController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c8a03ea70f482948b66d0c56c903062
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added screenshake to camera, which is triggered when ball hits something. The intensity can be adjusted in the editor.

While testing the game, I noticed that the ball would sometimes change direction awkwardly. This is due to how the ball loop prevention was implemented, as it would tweak ball velocity every time it bounced. The fix to this was simple: the script now only tweaks y-velocity when y-velocity is below 1 and above -1 so it now behaves more naturally when no tweaking is needed.